### PR TITLE
Input streams instead of files

### DIFF
--- a/src/main/java/masecla/modrinth4j/endpoints/generic/Endpoint.java
+++ b/src/main/java/masecla/modrinth4j/endpoints/generic/Endpoint.java
@@ -1,8 +1,11 @@
 package masecla.modrinth4j.endpoints.generic;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -133,15 +136,26 @@ public abstract class Endpoint<O, I> {
         }
     }
 
+    protected byte[] readStream(InputStream stream){
+        try {
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            int nRead;
+            byte[] data = new byte[16384];
+            while ((nRead = stream.read(data, 0, data.length)) != -1) {
+                buffer.write(data, 0, nRead);
+            }
+            buffer.flush();
+            return buffer.toByteArray();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
     protected byte[] readFile(File file) {
         try {
-            FileInputStream fis = new FileInputStream(file);
-            byte[] data = new byte[(int) file.length()];
-            fis.read(data);
-            fis.close();
-
-            return data;
-        } catch (IOException e) {
+            return readStream(new FileInputStream(file));
+        } catch (FileNotFoundException e) {
             e.printStackTrace();
             return null;
         }

--- a/src/main/java/masecla/modrinth4j/endpoints/project/ChangeProjectIcon.java
+++ b/src/main/java/masecla/modrinth4j/endpoints/project/ChangeProjectIcon.java
@@ -30,7 +30,7 @@ public class ChangeProjectIcon extends Endpoint<EmptyResponse, ChangeProjectIcon
     @AllArgsConstructor
     public static class ChangeProjectIconRequest {
         public InputStream icon;
-        public String ext;
+        public String iconName;
     }
 
     @Override
@@ -53,8 +53,7 @@ public class ChangeProjectIcon extends Endpoint<EmptyResponse, ChangeProjectIcon
         // Once again, Modrinth is a bit weird with their API. They use query parameters
         // to determine the file extension of the icon in a PATCH request.
         // Also, this whole endpoint is undocumented
-
-        String ext = request.getExt();
+        String ext = request.getIconName().substring(request.getIconName().lastIndexOf(".") + 1);
         return super.getReplacedUrl(request, parameters) + "?ext=" + ext;
     }
 

--- a/src/main/java/masecla/modrinth4j/endpoints/project/ChangeProjectIcon.java
+++ b/src/main/java/masecla/modrinth4j/endpoints/project/ChangeProjectIcon.java
@@ -1,7 +1,7 @@
 package masecla.modrinth4j.endpoints.project;
 
-import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -29,7 +29,8 @@ public class ChangeProjectIcon extends Endpoint<EmptyResponse, ChangeProjectIcon
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ChangeProjectIconRequest {
-        public File icon;
+        public InputStream icon;
+        public String ext;
     }
 
     @Override
@@ -53,7 +54,7 @@ public class ChangeProjectIcon extends Endpoint<EmptyResponse, ChangeProjectIcon
         // to determine the file extension of the icon in a PATCH request.
         // Also, this whole endpoint is undocumented
 
-        String ext = request.getIcon().getName().substring(request.getIcon().getName().lastIndexOf(".") + 1);
+        String ext = request.getExt();
         return super.getReplacedUrl(request, parameters) + "?ext=" + ext;
     }
 
@@ -62,9 +63,8 @@ public class ChangeProjectIcon extends Endpoint<EmptyResponse, ChangeProjectIcon
         String url = getReplacedUrl(request, urlParams);
         return getClient().connect(url).thenApply(c -> {
             try {
-                File f = request.getIcon();
-
-                c.method(getMethod(), RequestBody.create(readFile(f)));
+                InputStream stream = request.getIcon();
+                c.method(getMethod(), RequestBody.create(readStream(stream)));
                 
                 Response response = getClient().execute(c);
                 checkBodyForErrors(response.body());

--- a/src/main/java/masecla/modrinth4j/endpoints/project/CreateProject.java
+++ b/src/main/java/masecla/modrinth4j/endpoints/project/CreateProject.java
@@ -1,7 +1,7 @@
 package masecla.modrinth4j.endpoints.project;
 
-import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -71,7 +71,8 @@ public class CreateProject extends Endpoint<Project, CreateProjectRequest> {
     public static class CreateProjectRequest {
         private ProjectData data;
 
-        private File icon;
+        private String iconFilename;
+        private InputStream iconData;
     }
 
     @Override
@@ -105,9 +106,9 @@ public class CreateProject extends Endpoint<Project, CreateProjectRequest> {
                 obj.addProperty("is_draft", true);
 
                 bodyBuilder.addFormDataPart("data", getGson().toJson(obj));
-                if (parameters.getIcon() != null)
-                    bodyBuilder.addFormDataPart("icon", parameters.getIcon().getName(),
-                            RequestBody.create(readFile(parameters.getIcon())));
+                if (parameters.getIconData() != null)
+                    bodyBuilder.addFormDataPart("icon", parameters.getIconFilename(),
+                            RequestBody.create(readStream(parameters.getIconData())));
 
                 c.method(getMethod(), bodyBuilder.build());
 

--- a/src/main/java/masecla/modrinth4j/endpoints/project/ProjectEndpoints.java
+++ b/src/main/java/masecla/modrinth4j/endpoints/project/ProjectEndpoints.java
@@ -1,6 +1,9 @@
 package masecla.modrinth4j.endpoints.project;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -105,10 +108,16 @@ public class ProjectEndpoints {
         return new UnfollowProject(client, gson).sendRequest(new EmptyRequest(), parameters);
     }
 
-    public CompletableFuture<EmptyResponse> changeProjectIcon(String projectId, File file){
+    public CompletableFuture<EmptyResponse> changeProjectIcon(String projectId, File file)
+            throws FileNotFoundException {
+        return changeProjectIcon(projectId, new FileInputStream(file), file.getName());
+    }
+
+    public CompletableFuture<EmptyResponse> changeProjectIcon(String projectId, InputStream stream, String fileName) {
         Map<String, String> parameters = new HashMap<>();
         parameters.put("id", projectId);
-        
-        return new ChangeProjectIcon(client, gson).sendRequest(new ChangeProjectIconRequest(file), parameters);
+
+        return new ChangeProjectIcon(client, gson).sendRequest(new ChangeProjectIconRequest(stream, fileName),
+                parameters);
     }
 }

--- a/src/main/java/masecla/modrinth4j/endpoints/project/gallery/CreateGalleryImage.java
+++ b/src/main/java/masecla/modrinth4j/endpoints/project/gallery/CreateGalleryImage.java
@@ -1,5 +1,8 @@
 package masecla.modrinth4j.endpoints.project.gallery;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -27,6 +30,19 @@ public class CreateGalleryImage extends Endpoint<EmptyResponse, CreateGalleryIma
         private boolean featured;
         private String title;
         private String description;
+
+        public static class CreateGalleryImageRequestBuilder {
+            public CreateGalleryImageRequestBuilder file(File file) {
+                try {
+                    this.filename = file.getName();
+                    this.image = new FileInputStream(file);
+                } catch (FileNotFoundException e) {
+                    e.printStackTrace();
+                }
+
+                return this;
+            }
+        }
     }
 
     public CreateGalleryImage(HttpClient client, Gson gson) {

--- a/src/main/java/masecla/modrinth4j/endpoints/project/gallery/CreateGalleryImage.java
+++ b/src/main/java/masecla/modrinth4j/endpoints/project/gallery/CreateGalleryImage.java
@@ -1,7 +1,7 @@
 package masecla.modrinth4j.endpoints.project.gallery;
 
-import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -21,7 +21,8 @@ public class CreateGalleryImage extends Endpoint<EmptyResponse, CreateGalleryIma
     @Data
     @Builder
     public static class CreateGalleryImageRequest {
-        private File file;
+        private String filename;
+        private InputStream image;
 
         private boolean featured;
         private String title;
@@ -47,8 +48,8 @@ public class CreateGalleryImage extends Endpoint<EmptyResponse, CreateGalleryIma
             Map<String, String> urlParams) {
         String url = getReplacedUrl(parameters, urlParams);
 
-        String extension = parameters.getFile().getName()
-                .substring(parameters.getFile().getName().lastIndexOf(".") + 1);
+        String extension = parameters.getFilename()
+                .substring(parameters.getFilename().lastIndexOf(".") + 1);
 
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put("ext", extension);
@@ -58,7 +59,7 @@ public class CreateGalleryImage extends Endpoint<EmptyResponse, CreateGalleryIma
 
         return getClient().connect(url, queryParams).thenApply(c -> {
             try {
-                c.method(getMethod(), RequestBody.create(readFile(parameters.getFile())));
+                c.method(getMethod(), RequestBody.create(readStream(parameters.getImage())));
                 c.header("Content-Type", "image/*");
 
                 Response response = getClient().execute(c);

--- a/src/main/java/masecla/modrinth4j/endpoints/user/ChangeUserIcon.java
+++ b/src/main/java/masecla/modrinth4j/endpoints/user/ChangeUserIcon.java
@@ -1,7 +1,7 @@
 package masecla.modrinth4j.endpoints.user;
 
-import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -29,7 +29,8 @@ public class ChangeUserIcon extends Endpoint<EmptyResponse, ChangeUserIconReques
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ChangeUserIconRequest {
-        public File icon;
+        private String filename;
+        private InputStream iconData;
     }
 
     @Override
@@ -53,7 +54,7 @@ public class ChangeUserIcon extends Endpoint<EmptyResponse, ChangeUserIconReques
         // to determine the file extension of the icon in a PATCH request.
         // Also, this behaviour is completely undocumented.
 
-        String ext = request.getIcon().getName().substring(request.getIcon().getName().lastIndexOf(".") + 1);
+        String ext = request.getFilename().substring(request.getFilename().lastIndexOf(".") + 1);
         return super.getReplacedUrl(request, parameters) + "?ext=" + ext;
     }
 
@@ -62,9 +63,8 @@ public class ChangeUserIcon extends Endpoint<EmptyResponse, ChangeUserIconReques
         String url = getReplacedUrl(request, urlParams);
         return getClient().connect(url).thenApply(c -> {
             try {
-                File f = request.getIcon();
-
-                c.method(getMethod(), RequestBody.create(readFile(f)));
+                InputStream stream = request.getIconData();
+                c.method(getMethod(), RequestBody.create(readStream(stream)));
                 
                 Response response = getClient().execute(c);
                 checkBodyForErrors(response.body());

--- a/src/main/java/masecla/modrinth4j/endpoints/user/UserEndpoints.java
+++ b/src/main/java/masecla/modrinth4j/endpoints/user/UserEndpoints.java
@@ -1,6 +1,9 @@
 package masecla.modrinth4j.endpoints.user;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -67,11 +70,15 @@ public class UserEndpoints {
         return new GetSelf(client, gson).sendRequest(new EmptyRequest(), new HashMap<>());
     }
 
-    public CompletableFuture<EmptyResponse> changeProfilePicture(String id, File file) {
+    public CompletableFuture<EmptyResponse> changeProfilePicture(String id, File file) throws FileNotFoundException {
+        return changeProfilePicture(id, new FileInputStream(file), file.getName());
+    }
+
+    public CompletableFuture<EmptyResponse> changeProfilePicture(String id, InputStream stream, String filename) {
         Map<String, String> parameters = new HashMap<>();
         parameters.put("id", id);
 
-        return new ChangeUserIcon(client, gson).sendRequest(new ChangeUserIconRequest(file), parameters);
+        return new ChangeUserIcon(client, gson).sendRequest(new ChangeUserIconRequest(filename, stream), parameters);
     }
 
     public CompletableFuture<Project[]> getUserProjects(String id) {
@@ -95,7 +102,8 @@ public class UserEndpoints {
         return new GetUserNotifications(client, gson).sendRequest(new EmptyRequest(), parameters);
     }
 
-    public CompletableFuture<ReportProjectUserOrVersionResponse> reportProjectUserOrVersion(ReportProjectUserOrVersionRequest request) {
+    public CompletableFuture<ReportProjectUserOrVersionResponse> reportProjectUserOrVersion(
+            ReportProjectUserOrVersionRequest request) {
         return new ReportProjectUserOrVersion(client, gson).sendRequest(request);
     }
 }

--- a/src/main/java/masecla/modrinth4j/endpoints/version/AddFilesToVersion.java
+++ b/src/main/java/masecla/modrinth4j/endpoints/version/AddFilesToVersion.java
@@ -1,6 +1,6 @@
 package masecla.modrinth4j.endpoints.version;
 
-import java.io.File;
+import java.io.InputStream;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -24,7 +24,8 @@ public class AddFilesToVersion extends Endpoint<EmptyResponse, AddFilesToVersion
     @NoArgsConstructor
     @AllArgsConstructor
     public static class AddFilesToVersionRequest {
-        public File[] files;
+        private String[] fileNames;
+        private InputStream[] fileStreams;
     }
 
     public AddFilesToVersion(HttpClient client, Gson gson) {
@@ -46,9 +47,9 @@ public class AddFilesToVersion extends Endpoint<EmptyResponse, AddFilesToVersion
             builder.addFormDataPart("data", "{}"); // Not sure what this is for, but it's required
 
             try {
-                for (File f : request.getFiles()) {
-                    builder.addFormDataPart(f.getName(), f.getName(), 
-                        RequestBody.create(this.readFile(f)));
+                for(int i = 0; i < request.getFileNames().length; i++) {
+                    builder.addFormDataPart(request.getFileNames()[i], request.getFileNames()[i], 
+                        RequestBody.create(this.readStream(request.getFileStreams()[i])));
                 }
 
                 c.post(builder.build());

--- a/src/main/java/masecla/modrinth4j/endpoints/version/CreateVersion.java
+++ b/src/main/java/masecla/modrinth4j/endpoints/version/CreateVersion.java
@@ -1,6 +1,6 @@
 package masecla.modrinth4j.endpoints.version;
 
-import java.io.File;
+import java.io.InputStream;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -32,10 +32,10 @@ public class CreateVersion extends Endpoint<ProjectVersion, CreateVersionRequest
     public static class CreateVersionRequest {
         @NonNull
         private String name;
-        
+
         @NonNull
         private String versionNumber;
-        
+
         @NonNull
         private String changelog;
 
@@ -43,19 +43,22 @@ public class CreateVersion extends Endpoint<ProjectVersion, CreateVersionRequest
         private ProjectDependency[] dependencies = new ProjectDependency[0];
         private String[] gameVersions;
         private VersionType versionType;
-        
+
         @NonNull
         private String[] loaders;
-        
+
         private boolean featured;
-        
+
         @NonNull
         private String projectId;
-        
+
         private String primaryFile;
-        
+
         @NonNull
-        private transient File[] files;
+        private transient String[] fileNames;
+
+        @NonNull
+        private transient InputStream[] fileStreams;
     }
 
     public CreateVersion(HttpClient client, Gson gson) {
@@ -73,17 +76,17 @@ public class CreateVersion extends Endpoint<ProjectVersion, CreateVersionRequest
         return getClient().connect(url).thenApply(c -> {
             JsonObject jsonObject = getGson().toJsonTree(request).getAsJsonObject();
 
-            if (request.getFiles().length > 1) {
+            if (request.getFileNames().length > 1) {
                 String primaryFile = request.getPrimaryFile();
                 if (primaryFile == null || primaryFile.isEmpty()) {
-                    primaryFile = request.getFiles()[0].getName();
+                    primaryFile = request.getFileNames()[0];
                 }
                 jsonObject.addProperty("primary_file", primaryFile);
             }
 
             JsonArray array = new JsonArray();
-            for (File file : request.getFiles()) {
-                array.add(file.getName());
+            for (String filename : request.getFileNames()) {
+                array.add(filename);
             }
             jsonObject.add("file_parts", array);
 
@@ -91,8 +94,11 @@ public class CreateVersion extends Endpoint<ProjectVersion, CreateVersionRequest
                     .addFormDataPart("data", getGson().toJson(jsonObject));
 
             try {
-                for (File file : request.getFiles())
-                    body.addFormDataPart(file.getName(), file.getName(), RequestBody.create(this.readFile(file)));
+                for (int i = 0; i < request.getFileNames().length; i++) {
+                    body.addFormDataPart(request.getFileNames()[i], request.getFileNames()[i],
+                            RequestBody.create(this.readStream(request.getFileStreams()[i])));
+                }
+
                 c.post(body.build());
 
                 Response response = this.getClient().execute(c);

--- a/src/main/java/masecla/modrinth4j/endpoints/version/CreateVersion.java
+++ b/src/main/java/masecla/modrinth4j/endpoints/version/CreateVersion.java
@@ -1,5 +1,7 @@
 package masecla.modrinth4j.endpoints.version;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -59,6 +61,22 @@ public class CreateVersion extends Endpoint<ProjectVersion, CreateVersionRequest
 
         @NonNull
         private transient InputStream[] fileStreams;
+
+        public static class CreateVersionRequestBuilder {
+            public CreateVersionRequestBuilder files(File[] files) {
+                try {
+                    this.fileNames = new String[files.length];
+                    this.fileStreams = new InputStream[files.length];
+                    for (int i = 0; i < files.length; i++) {
+                        this.fileNames[i] = files[i].getName();
+                        this.fileStreams[i] = new FileInputStream(files[i]);
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                return this;
+            }
+        }
     }
 
     public CreateVersion(HttpClient client, Gson gson) {

--- a/src/main/java/masecla/modrinth4j/endpoints/version/VersionEndpoints.java
+++ b/src/main/java/masecla/modrinth4j/endpoints/version/VersionEndpoints.java
@@ -1,6 +1,9 @@
 package masecla.modrinth4j.endpoints.version;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -63,10 +66,24 @@ public class VersionEndpoints {
         return new CreateVersion(httpClient, gson).sendRequest(request);
     }
 
-    public CompletableFuture<EmptyResponse> addFilesToVersion(String versionId, File[] files) {
+    public CompletableFuture<EmptyResponse> addFilesToVersion(String versionId, InputStream[] files,
+            String[] fileNames) {
         Map<String, String> parameters = new HashMap<>();
         parameters.put("id", versionId);
 
-        return new AddFilesToVersion(httpClient, gson).sendRequest(new AddFilesToVersionRequest(files), parameters);
+        return new AddFilesToVersion(httpClient, gson).sendRequest(new AddFilesToVersionRequest(
+                fileNames, files), parameters);
+    }
+
+    public CompletableFuture<EmptyResponse> addFilesToVersion(String versionId, File[] files) throws FileNotFoundException{
+        InputStream[] streams = new InputStream[files.length];
+        String[] names = new String[files.length];
+
+        for (int i = 0; i < files.length; i++) {
+            streams[i] = new FileInputStream(files[i]);
+            names[i] = files[i].getName();
+        }
+
+        return addFilesToVersion(versionId, streams, names);
     }
 }

--- a/src/test/java/masecla/modrinth4j/client/ProjectEndpointsTests.java
+++ b/src/test/java/masecla/modrinth4j/client/ProjectEndpointsTests.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
 
+import lombok.SneakyThrows;
 import masecla.modrinth4j.data.DataUtil;
 import masecla.modrinth4j.endpoints.SearchEndpoint.SearchRequest;
 import masecla.modrinth4j.endpoints.SearchEndpoint.SearchResponse;
@@ -41,6 +42,7 @@ public class ProjectEndpointsTests {
     }
 
     @Test
+    @SneakyThrows
     public void testIconChange() {
         Project prj = DataUtil.createSampleProject(client);
 

--- a/src/test/java/masecla/modrinth4j/client/UserEndpointsTests.java
+++ b/src/test/java/masecla/modrinth4j/client/UserEndpointsTests.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletionException;
 import org.junit.Before;
 import org.junit.Test;
 
+import lombok.SneakyThrows;
 import masecla.modrinth4j.data.DataUtil;
 import masecla.modrinth4j.endpoints.user.ModifyUser.ModifyUserRequest;
 import masecla.modrinth4j.endpoints.user.ReportProjectUserOrVersion.ReportProjectUserOrVersionRequest;
@@ -85,6 +86,7 @@ public class UserEndpointsTests {
     }
 
     @Test
+    @SneakyThrows
     public void testChangeProfilePicture() {
         ModrinthUser self = client.users().getSelf().join();
         client.users().changeProfilePicture(self.getId(), DataUtil.getImage()).join();

--- a/src/test/java/masecla/modrinth4j/client/VersionEndpointsTests.java
+++ b/src/test/java/masecla/modrinth4j/client/VersionEndpointsTests.java
@@ -8,6 +8,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import lombok.SneakyThrows;
 import masecla.modrinth4j.data.DataUtil;
 import masecla.modrinth4j.endpoints.version.CreateVersion.CreateVersionRequest;
 import masecla.modrinth4j.endpoints.version.GetProjectVersions.GetProjectVersionsRequest;
@@ -127,6 +128,7 @@ public class VersionEndpointsTests {
     }
 
     @Test
+    @SneakyThrows
     public void testAddFilesToVersion() {
         Project prj = DataUtil.fetchSampleProject(client);
         ProjectVersion version = DataUtil.appendVersion(client, prj.getId());
@@ -147,6 +149,7 @@ public class VersionEndpointsTests {
     }
 
     @Test
+    @SneakyThrows
     public void testGetVersionsByHash() {
         Project prj = DataUtil.fetchSampleProject(client);
         ProjectVersion version = DataUtil.appendVersion(client, prj.getId());
@@ -167,6 +170,7 @@ public class VersionEndpointsTests {
     }
 
     @Test
+    @SneakyThrows
     public void testDeleteFileByHash() {
         Project prj = DataUtil.fetchSampleProject(client);
         ProjectVersion version = DataUtil.appendVersion(client, prj.getId());
@@ -194,6 +198,7 @@ public class VersionEndpointsTests {
     }
 
     @Test
+    @SneakyThrows
     public void testGetLatestVersionsByHash() {
         Project prj = DataUtil.fetchSampleProject(client);
         ProjectVersion version = DataUtil.appendVersion(client, prj.getId());


### PR DESCRIPTION
This merge request replaces all Files used by the library with InputStreams internally and provides access to them, as well as rebuilding the convenience methods for files as to not break compatibility. 