### PR TITLE
Change FileHash SHA-256 to SHA-512 

### DIFF
--- a/src/main/java/masecla/modrinth4j/model/version/FileHash.java
+++ b/src/main/java/masecla/modrinth4j/model/version/FileHash.java
@@ -9,7 +9,7 @@ public enum FileHash {
     /** Represents the SHA1 hash */
     @SerializedName("sha1")
     SHA1,
-    /** Represents the SHA256 hash */
-    @SerializedName("sha256")
-    SHA256;
+    /** Represents the SHA512 hash */
+    @SerializedName("sha512")
+    SHA512;
 }

--- a/src/test/java/masecla/modrinth4j/client/VersionEndpointsTests.java
+++ b/src/test/java/masecla/modrinth4j/client/VersionEndpointsTests.java
@@ -187,6 +187,20 @@ public class VersionEndpointsTests {
     }
 
     /**
+     * This method tests getting a version by hash SHA-512
+     */
+    @Test
+    public void testGetVersionByHash512() {
+        Project prj = DataUtil.fetchSampleProject(client);
+        ProjectVersion version = DataUtil.appendVersion(client, prj.getId());
+
+        ProjectVersion vers = client.versions().files()
+                .getVersionByHash(FileHash.SHA512, version.getFiles().get(0).getHashes().getSha512()).join();
+
+        assertEquals(vers.getId(), version.getId());
+    }
+
+    /**
      * This method tests getting multiple versions by hash
      */
     @Test


### PR DESCRIPTION
- I've removed FileHash.SHA256 and replaced it with SHA512
- Updated the documentation
- Added Unit test that tests getting a version with the SHA-512 hash

As in the [docs](https://docs.modrinth.com/api-spec/#tag/version-files/operation/versionFromHash) all the Version File endpoints use only sha1 or sha512 query parameter

Fixes #3 